### PR TITLE
Support custom Page classes with PHPDoc injection

### DIFF
--- a/AutoTemplateStubs.module.php
+++ b/AutoTemplateStubs.module.php
@@ -37,10 +37,13 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 * Ready
 	 */
 	public function ready() {
+		$this->addHookAfter('Fieldtype::renamedField', $this, 'hookRenamedField');
+		$this->addHookAfter('Templates::renamed', $this, 'hookRenamedTemplate');
 		$this->addHookAfter('Fields::save', $this, 'fieldSaved');
 		$this->addHookAfter('Fields::saveFieldgroupContext', $this, 'fieldContextSaved');
 		$this->addHookBefore('Fieldgroups::save', $this, 'fieldgroupSaved');
 		$this->addHookAfter('Fieldgroups::delete', $this, 'fieldgroupDeleted');
+		$this->addHookAfter('Fields::delete', $this, 'fieldDeleted');
 		$this->addHookBefore('Modules::saveModuleConfigData', $this, 'moduleConfigSaved');
 	}
 
@@ -65,32 +68,17 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 				}
 			},
 			'FieldtypeFile' => function (Field $field) {
-				switch($field->outputFormat) {
-					case FieldtypeFile::outputFormatArray:
-						return 'Pagefiles';
-					case FieldtypeFile::outputFormatSingle:
-						return 'Pagefile|null';
-					case FieldtypeFile::outputFormatString:
-						return 'string';
-					default: // outputFormatAuto
-						return $field->maxFiles == 1 ? 'Pagefile|null' : 'Pagefiles';
-				}
+				return $this->resolveFileImageType($field, 'file');
 			},
 			'FieldtypeFloat' => 'float',
 			'FieldtypeImage' => function (Field $field) {
-				switch($field->outputFormat) {
-					case FieldtypeImage::outputFormatArray:
-						return 'Pageimages';
-					case FieldtypeImage::outputFormatSingle:
-						return 'Pageimage|null';
-					case FieldtypeImage::outputFormatString:
-						return 'string';
-					default: // outputFormatAuto
-						return $field->maxFiles == 1 ? 'Pageimage|null' : 'Pageimages';
-				}
+				return $this->resolveFileImageType($field, 'image');
 			},
 			'FieldtypeInteger' => 'int',
 			'FieldtypeModule' => 'string',
+			'FieldtypeMultiplier' => function (Field $field) {
+				return $this->getMultiplierReturnType($field);
+			},
 			'FieldtypeOptions' => 'SelectableOptionArray',
 			'FieldtypePage' => function (Field $field) {
 				switch($field->derefAsPage) {
@@ -98,7 +86,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 						return 'Page|false';
 					case FieldtypePage::derefAsPageOrNullPage:
 						return 'Page|NullPage';
-					default: // derefAsPageArray
+					default:
 						return 'PageArray';
 				}
 			},
@@ -114,15 +102,299 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 					return "RepeaterPageArray|{$this->class_prefix}repeater_{$field->name}[]";
 				}
 			},
+			'FieldtypeRepeaterMatrix' => function (Field $field) {
+				if(!method_exists($field, 'getMatrixTypesInfo')) return 'RepeaterMatrixPageArray';
+				$matrixTypes = $field->getMatrixTypesInfo();
+				$types = array('RepeaterMatrixPageArray');
+				
+				foreach($matrixTypes as $typeName => $typeInfo) {
+					if($this->custom_page_class_compatible) {
+						$fieldClassName = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
+						$className = "RepeaterMatrix{$fieldClassName}_" . ucfirst($this->wire()->sanitizer->camelCase($typeName));
+					} else {
+						$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeName}";
+					}
+					$types[] = $className . '[]';
+				}
+				
+				return implode('|', $types);
+			},
 			'FieldtypeSelector' => 'string',
+			'FieldtypeTable' => function (Field $field) {
+				return $this->getTableRowsReturnType($field);
+			},
 			'FieldtypeText' => 'string',
 			'FieldtypeTextLanguage' => 'string',
 			'FieldtypeTextarea' => 'string',
 			'FieldtypeTextareaLanguage' => 'string',
+			'FieldtypeTextareas' => function (Field $field) {
+				return $this->getTextareasReturnType($field);
+			},
 			'FieldtypeCombo' => function (Field $field) {
 				return "ComboValue_{$field->name}";
 			},
+			'FieldtypeCustom' => function (Field $field) {
+				return "CustomField_{$field->name}";
+			},
 		);
+	}
+
+	/**
+	 * Resolve File or Image field type based on outputFormat and maxFiles
+	 *
+	 * @param Field|Inputfield $obj Field or Inputfield object
+	 * @param string $type 'file' or 'image'
+	 * @return string
+	 */
+	protected function resolveFileImageType($obj, $type) {
+		$isImage = ($type === 'image');
+		$single = $isImage ? 'Pageimage|null' : 'Pagefile|null';
+		$multiple = $isImage ? 'Pageimages' : 'Pagefiles';
+		
+		$outputFormat = $obj instanceof Field ? $obj->outputFormat : $obj->get('outputFormat');
+		
+		if($outputFormat !== null) {
+			if($outputFormat == FieldtypeFile::outputFormatArray) return $multiple;
+			if($outputFormat == FieldtypeFile::outputFormatSingle) return $single;
+			if($outputFormat == FieldtypeFile::outputFormatString) return 'string';
+		}
+		
+		$maxFiles = $obj instanceof Field ? $obj->maxFiles : $obj->maxFiles;
+		return $maxFiles == 1 ? $single : $multiple;
+	}
+
+	/**
+	 * Get return type for a given Fieldtype class name
+	 *
+	 * @param string $fieldtypeClass
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getReturnTypeForFieldtypeClass($fieldtypeClass, Field $field) {
+		$return_types = $this->getReturnTypes();
+		if(!isset($return_types[$fieldtypeClass])) return 'mixed';
+		$return_type = $return_types[$fieldtypeClass];
+		if(is_callable($return_type)) $return_type = $return_type($field);
+		return $return_type ? $return_type : 'mixed';
+	}
+
+	/**
+	 * Get return type for a Table field
+	 *
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getTableRowsReturnType(Field $field) {
+		$className = $this->getTableRowsClassName($field);
+		return "$className|TableRows";
+	}
+
+	/**
+	 * Get return type for a Textareas field
+	 *
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getTextareasReturnType(Field $field) {
+		$className = $this->getTextareasDataClassName($field);
+		return "$className|TextareasData";
+	}
+
+	/**
+	 * Get return type for a Multiplier field
+	 *
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getMultiplierReturnType(Field $field) {
+		$itemType = 'mixed';
+		$fieldtype = $field->type;
+		if($fieldtype && method_exists($fieldtype, 'getFieldtype')) {
+			$baseFieldtype = $fieldtype->getFieldtype($field);
+			if($baseFieldtype) {
+				$itemType = $this->getReturnTypeForFieldtypeClass($baseFieldtype->className(), $field);
+			}
+		}
+		$itemArrayType = $this->getArrayType($itemType);
+		return "MultiplierArray|$itemArrayType";
+	}
+
+	/**
+	 * Get class name for TableRows stub
+	 *
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getTableRowsClassName(Field $field) {
+		return ucfirst($field->name) . 'TableRows';
+	}
+
+	/**
+	 * Get class name for TableRow stub
+	 *
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getTableRowClassName(Field $field) {
+		return ucfirst($field->name) . 'TableRow';
+	}
+
+	/**
+	 * Get class name for TextareasData stub
+	 *
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getTextareasDataClassName(Field $field) {
+		return "TextareasData_{$field->name}";
+	}
+
+	/**
+	 * Format an array type from a value type
+	 *
+	 * @param string $type
+	 * @return string
+	 */
+	protected function getArrayType($type) {
+		if(strpos($type, '|') !== false) {
+			return "($type)[]";
+		}
+		return $type . '[]';
+	}
+
+	/**
+	 * Map FieldtypeTable column metadata to PHPDoc return types
+	 *
+	 * @param array $col
+	 * @return string
+	 */
+	protected function getTableColumnReturnType(array $col) {
+		if(empty($col['valid'])) return 'mixed';
+		switch($col['valid']) {
+			case 'text':
+			case 'textarea':
+			case 'email':
+			case 'url':
+			case 'html':
+				return 'string';
+			case 'int':
+				return 'int';
+			case 'float':
+			case 'double':
+			case 'decimal':
+				return 'float';
+			case 'date':
+			case 'datetime':
+				return 'int|string';
+			case 'time':
+				return 'string|int';
+			case 'toggle':
+				return 'int|string';
+			case 'array':
+			case 'textTags':
+				return 'array';
+			case 'Page':
+				return 'Page|NullPage';
+			case 'PageArray':
+				return 'PageArray';
+			case 'LanguagesPageFieldValue':
+				return 'LanguagesPageFieldValue';
+			case 'file':
+				return 'Pagefile|null';
+			case 'image':
+				return 'Pageimage|null';
+			default:
+				return 'mixed';
+		}
+	}
+
+	/**
+	 * Derive return type for Textareas definitions
+	 *
+	 * @param Field $field
+	 * @return string
+	 */
+	protected function getTextareasDefinitionReturnType(Field $field) {
+		$fieldtype = $field->type;
+		if(!$fieldtype || !method_exists($fieldtype, 'getValueType')) return 'string';
+		$type = $fieldtype->getValueType($field, 'type');
+		$fieldtypeClass = $fieldtype->getValueType($field, 'fieldtype');
+		if($fieldtypeClass) {
+			return $this->getReturnTypeForFieldtypeClass($fieldtypeClass, $field);
+		}
+		switch($type) {
+			case 'Array':
+				return 'array';
+			case 'PageArray':
+				return 'PageArray';
+			case 'Page':
+				return 'Page|NullPage';
+			case 'Boolean':
+				return 'int';
+			case 'Text':
+			case 'Textarea':
+				return 'string';
+			default:
+				return 'mixed';
+		}
+	}
+
+	/**
+	 * Explicit Inputfield return-type map (used by FieldtypeCustom)
+	 *
+	 * @return array
+	 */
+	public function ___getInputfieldReturnTypes() {
+		return array(
+			'InputfieldInteger' => 'int',
+			'InputfieldFloat' => 'float',
+			'InputfieldCheckbox' => 'int',
+			'InputfieldDatetime' => 'int|string',
+			'InputfieldPage' => function(Inputfield $f) {
+				$deref = $f->derefAsPage;
+				if($deref == FieldtypePage::derefAsPageOrFalse) return 'Page|false';
+				if($deref == FieldtypePage::derefAsPageOrNullPage) return 'Page|NullPage';
+				return 'PageArray';
+			},
+			'InputfieldSelect' => function(Inputfield $f) {
+				return $f->attr('multiple') ? 'array' : 'string';
+			},
+			'InputfieldCheckboxes' => 'array',
+			'InputfieldAsmSelect' => 'array',
+			'InputfieldPageListSelectMultiple' => 'array',
+			'InputfieldTextTags' => 'string',
+			'InputfieldRadios' => 'string',
+			'InputfieldToggle' => 'int',
+			'InputfieldTinyMCE' => 'string',
+			'InputfieldCKEditor' => 'string',
+			'InputfieldFieldset' => null,
+		);
+	}
+
+	/**
+	 * Hook Fieldtype::renamedField
+	 * 
+	 * @param HookEvent $event
+	 */
+	protected function hookRenamedField(HookEvent $event) {
+		$field = $event->arguments(0);
+		$prevName = $event->arguments(1);
+		
+		// Clone field and set to old name to reuse delete logic
+		$oldField = clone $field;
+		$oldField->name = $prevName;
+		
+		$this->deleteFieldStub($oldField);
+	}
+
+	/**
+	 * Hook Templates::renamed
+	 * 
+	 * @param HookEvent $event
+	 */
+	protected function hookRenamedTemplate(HookEvent $event) {
+		$oldName = $event->arguments(1);
+		$this->deleteTemplateStub($oldName);
 	}
 
 	/**
@@ -132,10 +404,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 */
 	protected function fieldSaved(HookEvent $event) {
 		$field = $event->arguments(0);
-		if(in_array((string) $field->type, $this->skip_fieldtypes)) return;
-		foreach($field->getTemplates() as $template) {
-			$this->generateTemplateStub($template);
-		}
+		$this->handleFieldSave($field, $field->getTemplates());
 	}
 
 	/**
@@ -144,8 +413,28 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 * @param HookEvent $event
 	 */
 	protected function fieldContextSaved(HookEvent $event) {
+		$field = $event->arguments(0);
 		$fieldgroup = $event->arguments(1);
-		foreach($fieldgroup->getTemplates() as $template) {
+		$this->handleFieldSave($field, $fieldgroup->getTemplates());
+	}
+
+	/**
+	 * Handle field save logic (shared by fieldSaved and fieldContextSaved)
+	 *
+	 * @param Field $field
+	 * @param Templates|array $templates
+	 */
+	protected function handleFieldSave(Field $field, $templates) {
+		$fieldType = (string) $field->type;
+		if(in_array($fieldType, $this->skip_fieldtypes)) return;
+		
+		if($fieldType === 'FieldtypeCombo') $this->generateComboStub($field);
+		if($fieldType === 'FieldtypeTable') $this->generateTableStubs($field);
+		if($fieldType === 'FieldtypeTextareas') $this->generateTextareasStub($field);
+		if($fieldType === 'FieldtypeRepeaterMatrix') $this->generateMatrixStub($field);
+		if($fieldType === 'FieldtypeCustom') $this->generateCustomFieldStub($field);
+		
+		foreach($templates as $template) {
 			if(in_array($template->name, $this->skip_templates)) continue;
 			$this->generateTemplateStub($template);
 		}
@@ -163,12 +452,6 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			if(in_array($template->name, $this->skip_templates)) continue;
 			$this->generateTemplateStub($template);
 		}
-		// If fieldgroup renamed, delete old stub
-		// There is surely a better way to get the existing fieldgroup name but can't get my head around track changes
-		$sql = "SELECT name FROM fieldgroups WHERE id = {$fieldgroup->id} LIMIT 1";
-		$query = $this->wire()->database->query($sql);
-		$existing_name = $query->fetch(\PDO::FETCH_COLUMN);
-		if($fieldgroup->name !== $existing_name) $this->deleteTemplateStub($existing_name);
 	}
 
 	/**
@@ -224,28 +507,68 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	}
 
 	/**
+	 * Field deleted
+	 *
+	 * @param HookEvent $event
+	 */
+	protected function fieldDeleted(HookEvent $event) {
+		$field = $event->arguments(0);
+		$this->deleteFieldStub($field);
+	}
+
+	/**
+	 * Delete stub file(s) for a field
+	 * 
+	 * @param Field $field
+	 */
+	protected function deleteFieldStub(Field $field) {
+		$stubs_path = $this->getStubsPath();
+		$files = array();
+
+		if((string) $field->type === 'FieldtypeCombo') {
+			$files[] = $stubs_path . "ComboValue_{$field->name}.php";
+		}
+		
+		if((string) $field->type === 'FieldtypeTable') {
+			$files[] = $stubs_path . $this->getTableRowClassName($field) . ".php";
+			$files[] = $stubs_path . $this->getTableRowsClassName($field) . ".php";
+		}
+		
+		if((string) $field->type === 'FieldtypeTextareas') {
+			$files[] = $stubs_path . $this->getTextareasDataClassName($field) . ".php";
+		}
+		
+		if((string) $field->type === 'FieldtypeCustom') {
+			$files[] = $stubs_path . "CustomField_{$field->name}.php";
+		}
+		
+		if((string) $field->type === 'FieldtypeRepeaterMatrix') {
+			// Match default naming
+			$p1 = $stubs_path . $this->class_prefix . "repeater_matrix_{$field->name}_*.php";
+			// Match custom page class naming
+			$camelField = ucfirst($this->wire()->sanitizer->camelCase($field->name));
+			$p2 = $stubs_path . "RepeaterMatrix{$camelField}Page_*.php";
+			
+			foreach(glob($p1) as $f) $files[] = $f;
+			foreach(glob($p2) as $f) $files[] = $f;
+		}
+
+		foreach($files as $file) {
+			if(is_file($file)) unlink($file);
+		}
+	}
+
+	/**
 	 * Get stub info for a field
 	 *
 	 * @param Field $field
 	 * @param Template|null $template
 	 * @return array
 	 */
-	protected function getFieldInfo(Field $field, Template $template = null) {
-		// If Combo field then create ComboValue class stub for the field
-		if($field instanceof ComboField) {
-			$settings = $field->getComboSettings();
-			$phpdoc = $settings->toPhpDoc(false, true);
-			$class_name = "ComboValue_{$field->name}";
-			$stubs_path = $this->getStubsPath();
-			if(!is_dir($stubs_path)) $this->wire()->files->mkdir($stubs_path, true);
-			$this->wire()->files->filePutContents($stubs_path . "$class_name.php", $phpdoc);
-		}
+	protected function getFieldInfo(Field $field, $template = null) {
 		if($template) $field = $template->fieldgroup->getFieldContext($field);
 		$field_type = (string) $field->type;
-		$return_types = $this->getReturnTypes();
-		$return_type = 'mixed'; // default
-		if(!empty($return_types[$field_type])) $return_type = $return_types[$field_type];
-		if(is_callable($return_type)) $return_type = $return_type($field);
+		$return_type = $this->getReturnTypeForFieldtypeClass($field_type, $field);
 		return array(
 			'label' => $field->label,
 			'returns' => $return_type,
@@ -258,30 +581,259 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 * @param Template $template
 	 */
 	protected function generateTemplateStub(Template $template) {
-		if($this->custom_page_class_compatible) {
-			$class_name = ucfirst($this->wire()->sanitizer->camelCase($template->name)) . 'Page';
-		} else {
-			$class_name = $this->class_prefix . str_replace('-',  '_', $template->name);
+		$class_name = $this->getTemplateClassName($template->name);
+		
+		// Determine parent class
+		$extends = 'Page';
+		if(strpos($template->name, 'repeater_') === 0) {
+			$fieldName = substr($template->name, 9);
+			$field = $this->wire()->fields->get($fieldName);
+			if($field) {
+				if($field->type instanceof FieldtypeRepeaterMatrix) {
+					$extends = 'RepeaterMatrixPage';
+				} elseif($field->type instanceof FieldtypeRepeater) {
+					$extends = 'RepeaterPage';
+				}
+			}
 		}
+
 		$contents = "<?php namespace ProcessWire;\n\n";
 		$template_name = $template->name;
 		if($template->label) $template_name .= " ($template->label)";
 		$contents .= "/**\n * Template: $template_name\n *";
 		foreach($template->fields as $field) {
 			if(in_array((string) $field->type, $this->skip_fieldtypes)) continue;
+			if($field->name === 'repeater_matrix_type') continue;
 			$field_info = $this->getFieldInfo($field, $template);
 			$contents .= "\n * @property {$field_info['returns']} \${$field->name} {$field_info['label']}";
 		}
-		$contents .= "\n */\nclass $class_name extends Page {}\n";
-		$stubs_path = $this->getStubsPath();
-		if(!is_dir($stubs_path)) $this->wire()->files->mkdir($stubs_path, true);
-		$this->wire()->files->filePutContents($stubs_path . "$class_name.php", $contents);
+		$contents .= "\n */\nclass $class_name extends $extends {}\n";
+		$this->writeStubFile($class_name, $contents);
+	}
+
+	/**
+	 * Generate stub file for a Combo field
+	 *
+	 * @param Field $field
+	 */
+	protected function generateComboStub(Field $field) {
+		if((string) $field->type !== 'FieldtypeCombo') return;
+		
+		$className = "ComboValue_{$field->name}";
+		$phpDoc = $field->getComboSettings()->toPhpDoc(false, true);
+		$this->writeStubFile($className, $phpDoc);
+	}
+
+	/**
+	 * Generate stub file for a FieldtypeCustom field
+	 *
+	 * @param Field $field
+	 */
+	protected function generateCustomFieldStub(Field $field) {
+		if((string) $field->type !== 'FieldtypeCustom') return;
+
+		/** @var FieldtypeCustom $fieldtype */
+		$fieldtype = $field->type;
+		$defs = $fieldtype->newCustomFieldDefs($field);
+		$defs->getInputfields($field->name);
+		$inputfields = $defs->getFlatInputfields();
+		
+		if(!is_array($inputfields)) $inputfields = array();
+
+		if(empty($inputfields) && $defs->getInputfields() instanceof InputfieldWrapper) {
+			$inputfields = array();
+			$collect = function($wrapper) use (&$collect, &$inputfields) {
+				foreach($wrapper as $f) {
+					$prop = $f->get(CustomFieldDefs::_property_name);
+					if($prop) $inputfields[$prop] = $f;
+					if($f instanceof InputfieldWrapper && count($f)) $collect($f);
+				}
+			};
+			$collect($defs->getInputfields());
+		}
+
+		if(empty($inputfields)) return;
+
+		$types = $this->getInputfieldReturnTypes();
+		$className = "CustomField_{$field->name}";
+		$properties = array();
+		
+		foreach($inputfields as $name => $f) {
+			$inputfieldClass = $f->className();
+			$type = null;
+			
+			if(array_key_exists($inputfieldClass, $types)) {
+				$type = $types[$inputfieldClass];
+				$type = is_callable($type) ? $type($f) : $type;
+			} else {
+				foreach($types as $class => $t) {
+					if($f instanceof $class) {
+						$type = is_callable($t) ? $t($f) : $t;
+						break;
+					}
+				}
+			}
+			
+			if($type === null) continue;
+			$type = $type ?: 'string';
+			$properties[] = " * @property $type \$$name {$f->label}";
+		}
+
+		if(empty($properties)) return;
+
+		$contents = "<?php namespace ProcessWire;\n\n";
+		$contents .= "/**\n * Custom Field: {$field->name}\n";
+		$contents .= implode("\n", $properties);
+		$contents .= "\n */\nclass $className extends CustomWireData {}\n";
+		
+		$this->writeStubFile($className, $contents);
+	}
+
+	/**
+	 * Generate stub files for a Table field
+	 *
+	 * @param Field $field
+	 */
+	protected function generateTableStubs(Field $field) {
+		if((string) $field->type !== 'FieldtypeTable') return;
+		
+		$rowClass = $this->getTableRowClassName($field);
+		$rowsClass = $this->getTableRowsClassName($field);
+		$fieldtype = $field->type;
+		$properties = array();
+		
+		if($fieldtype && method_exists($fieldtype, 'getColumns')) {
+			foreach($fieldtype->getColumns($field) as $col) {
+				if(empty($col['name'])) continue;
+				$name = $this->wire()->sanitizer->fieldName($col['name']);
+				if(!$name) continue;
+				$type = $this->getTableColumnReturnType($col);
+				$label = isset($col['label']) ? $col['label'] : '';
+				$properties[] = " * @property $type \$$name $label";
+			}
+		}
+		
+		$contents = "<?php namespace ProcessWire;\n\n";
+		$contents .= "/**\n * Table Field: {$field->name}\n";
+		if($properties) $contents .= implode("\n", $properties);
+		$contents .= "\n * @property int|null \$rowId Row ID";
+		$contents .= "\n */\nclass $rowClass extends TableRow {}\n";
+		$this->writeStubFile($rowClass, $contents);
+		
+		$contents = "<?php namespace ProcessWire;\n\n";
+		$contents .= "/**\n * Table Field: {$field->name}\n";
+		$contents .= " * @method $rowClass new(array \$data = array())\n";
+		$contents .= " * @method $rowClass makeBlankItem()\n";
+		$contents .= " */\nclass $rowsClass extends TableRows {}\n";
+		$this->writeStubFile($rowsClass, $contents);
+	}
+
+	/**
+	 * Generate stub file for a Textareas field
+	 *
+	 * @param Field $field
+	 */
+	protected function generateTextareasStub(Field $field) {
+		if((string) $field->type !== 'FieldtypeTextareas') return;
+		
+		$className = $this->getTextareasDataClassName($field);
+		$fieldtype = $field->type;
+		if(!$fieldtype || !method_exists($fieldtype, 'getTextareaDefinitions')) return;
+		
+		$definitions = $fieldtype->getTextareaDefinitions($field);
+		if(!is_array($definitions) || empty($definitions)) return;
+		
+		$type = $this->getTextareasDefinitionReturnType($field);
+		$properties = array();
+		
+		foreach($definitions as $name => $definition) {
+			$label = is_array($definition) && isset($definition[0]) ? $definition[0] : '';
+			$properties[] = " * @property $type \$$name $label";
+		}
+		
+		if(empty($properties)) return;
+		
+		$contents = "<?php namespace ProcessWire;\n\n";
+		$contents .= "/**\n * Textareas Field: {$field->name}\n";
+		$contents .= implode("\n", $properties);
+		$contents .= "\n */\nclass $className extends TextareasData {}\n";
+		
+		$this->writeStubFile($className, $contents);
+	}
+
+	/**
+	 * Generate stub files for a RepeaterMatrix field
+	 *
+	 * @param Field $field
+	 */
+	protected function generateMatrixStub(Field $field) {
+		if((string) $field->type !== 'FieldtypeRepeaterMatrix') return;
+		
+		$matrixTypes = $field->getMatrixTypesInfo();
+		if(empty($matrixTypes)) return;
+		
+		foreach($matrixTypes as $typeName => $typeInfo) {
+			$this->generateMatrixTypeStub($field, $typeName, $typeInfo);
+		}
+	}
+
+	/**
+	 * Generate stub file for a single matrix type
+	 *
+	 * @param Field $field
+	 * @param string $typeName
+	 * @param array $typeInfo
+	 */
+	protected function generateMatrixTypeStub(Field $field, $typeName, array $typeInfo) {
+		if($this->custom_page_class_compatible) {
+			$fieldClassName = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
+			$className = "RepeaterMatrix{$fieldClassName}_" . ucfirst($this->wire()->sanitizer->camelCase($typeName));
+		} else {
+			$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeName}";
+		}
+		
+		$properties = array();
+		if(!empty($typeInfo['fields'])) {
+			foreach($typeInfo['fields'] as $subField) {
+				$fieldInfo = $this->getFieldInfo($subField);
+				$properties[] = " * @property {$fieldInfo['returns']} \${$subField->name} {$fieldInfo['label']}";
+			}
+		}
+		
+		$contents = "<?php namespace ProcessWire;\n\n";
+		$contents .= "/**\n";
+		$contents .= " * Matrix Type: {$typeInfo['label']}\n";
+		$contents .= " * Field: {$field->name}\n";
+		if($properties) $contents .= " *\n" . implode("\n", $properties);
+		$contents .= "\n */\nclass $className extends RepeaterMatrixPage {}\n";
+		
+		$this->writeStubFile($className, $contents);
 	}
 
 	/**
 	 * Generate stub files for all templates
 	 */
 	protected function generateAllTemplateStubs() {
+		foreach($this->wire()->fields->findByType('FieldtypeCombo') as $field) {
+			$this->generateComboStub($field);
+		}
+
+		foreach($this->wire()->fields->findByType('FieldtypeTable') as $field) {
+			$this->generateTableStubs($field);
+		}
+
+		foreach($this->wire()->fields->findByType('FieldtypeTextareas') as $field) {
+			$this->generateTextareasStub($field);
+		}
+		
+		foreach($this->wire()->fields->findByType('FieldtypeRepeaterMatrix') as $field) {
+			$this->generateMatrixStub($field);
+		}
+
+		foreach($this->wire()->fields->findByType('FieldtypeCustom') as $field) {
+			$this->generateCustomFieldStub($field);
+		}
+		
 		foreach($this->wire()->templates as $template) {
 			if(in_array($template->name, $this->skip_templates)) continue;
 			$this->generateTemplateStub($template);
@@ -291,12 +843,39 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	/**
 	 * Delete stub file for a template
 	 *
-	 * @param string $fieldgroup_name
+	 * @param string $templateName
 	 */
-	protected function deleteTemplateStub($fieldgroup_name) {
-		$stub_name = $this->class_prefix . $fieldgroup_name;
-		$file_path = $this->getStubsPath() . "$stub_name.php";
+	protected function deleteTemplateStub($templateName) {
+		$className = $this->getTemplateClassName($templateName);
+		$file_path = $this->getStubsPath() . "$className.php";
 		if(is_file($file_path)) unlink($file_path);
+	}
+
+	/**
+	 * Get the class name for a given template name
+	 * 
+	 * @param string $templateName
+	 * @return string
+	 */
+	protected function getTemplateClassName($templateName) {
+		if($this->custom_page_class_compatible) {
+			return ucfirst($this->wire()->sanitizer->camelCase($templateName)) . 'Page';
+		} else {
+			return $this->class_prefix . str_replace('-',  '_', $templateName);
+		}
+	}
+
+	/**
+	 * Write stub content to file
+	 * 
+	 * @param string $className
+	 * @param string $contents
+	 * @return int|bool
+	 */
+	protected function writeStubFile($className, $contents) {
+		$stubs_path = $this->getStubsPath();
+		if(!is_dir($stubs_path)) $this->wire()->files->mkdir($stubs_path, true);
+		return $this->wire()->files->filePutContents($stubs_path . "$className.php", $contents);
 	}
 
 	/**

--- a/AutoTemplateStubs.module.php
+++ b/AutoTemplateStubs.module.php
@@ -112,7 +112,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 						$fieldClassName = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
 						$className = "RepeaterMatrix{$fieldClassName}_" . ucfirst($this->wire()->sanitizer->camelCase($typeName));
 					} else {
-						$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeName}";
+						$typeSlug = str_replace('-', '_', $typeName);
+						$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeSlug}";
 					}
 					$types[] = $className . '[]';
 				}
@@ -545,6 +546,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 		if((string) $field->type === 'FieldtypeRepeaterMatrix') {
 			// Match default naming
 			$p1 = $stubs_path . $this->class_prefix . "repeater_matrix_{$field->name}_*.php";
+			$p1 = str_replace('-', '_', $p1);
 			// Match custom page class naming
 			$camelField = ucfirst($this->wire()->sanitizer->camelCase($field->name));
 			$p2 = $stubs_path . "RepeaterMatrix{$camelField}Page_*.php";
@@ -789,7 +791,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			$fieldClassName = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
 			$className = "RepeaterMatrix{$fieldClassName}_" . ucfirst($this->wire()->sanitizer->camelCase($typeName));
 		} else {
-			$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeName}";
+			$typeSlug = str_replace('-', '_', $typeName);
+			$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeSlug}";
 		}
 		
 		$properties = array();

--- a/AutoTemplateStubs.module.php
+++ b/AutoTemplateStubs.module.php
@@ -363,6 +363,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			'InputfieldCheckboxes' => 'array',
 			'InputfieldAsmSelect' => 'array',
 			'InputfieldPageListSelectMultiple' => 'array',
+			'InputfieldText' => 'string',
+			'InputfieldTextarea' => 'string',
 			'InputfieldTextTags' => 'string',
 			'InputfieldRadios' => 'string',
 			'InputfieldToggle' => 'int',
@@ -676,7 +678,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 				}
 			}
 			
-			if($type === null) continue;
+			if($type === null) $type = 'mixed';
 			$type = $type ?: 'string';
 			$properties[] = " * @property $type \$$name {$f->label}";
 		}

--- a/AutoTemplateStubs.module.php
+++ b/AutoTemplateStubs.module.php
@@ -31,6 +31,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 		$this->custom_page_class_compatible = 0;
 		$this->class_prefix = 'tpl_';
 		$this->stubs_path_relative = '/site/templates/';
+		$this->inject_custom_page_class_phpdoc = 0;
 	}
 
 	/**
@@ -61,8 +62,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			'FieldtypeEmail' => 'string',
 			'FieldtypeFieldsetPage' => function (Field $field) {
 				if($this->custom_page_class_compatible) {
-					$class_name = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
-					return "FieldsetPage|Repeater{$class_name}";
+					$class_name = $this->wire()->sanitizer->pascalCase($field->name) . 'FieldsetPage';
+					return "FieldsetPage|{$class_name}";
 				} else {
 					return "FieldsetPage|{$this->class_prefix}repeater_{$field->name}";
 				}
@@ -96,8 +97,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			'FieldtypePassword' => 'Password',
 			'FieldtypeRepeater' => function (Field $field) {
 				if($this->custom_page_class_compatible) {
-					$class_name = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
-					return "RepeaterPageArray|Repeater{$class_name}[]";
+					$class_name = $this->wire()->sanitizer->pascalCase($field->name) . 'RepeaterPage';
+					return "RepeaterPageArray|{$class_name}[]";
 				} else {
 					return "RepeaterPageArray|{$this->class_prefix}repeater_{$field->name}[]";
 				}
@@ -109,8 +110,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 				
 				foreach($matrixTypes as $typeName => $typeInfo) {
 					if($this->custom_page_class_compatible) {
-						$fieldClassName = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
-						$className = "RepeaterMatrix{$fieldClassName}_" . ucfirst($this->wire()->sanitizer->camelCase($typeName));
+						$fieldClassName = $this->wire()->sanitizer->pascalCase($field->name) . 'RepeaterMatrixPage';
+						$className = "{$fieldClassName}_" . $this->wire()->sanitizer->pascalCase($typeName);
 					} else {
 						$typeSlug = str_replace('-', '_', $typeName);
 						$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeSlug}";
@@ -227,7 +228,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 * @return string
 	 */
 	protected function getTableRowsClassName(Field $field) {
-		return ucfirst($field->name) . 'TableRows';
+		return $this->wire()->sanitizer->pascalCase($field->name) . 'TableRows';
 	}
 
 	/**
@@ -237,7 +238,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 * @return string
 	 */
 	protected function getTableRowClassName(Field $field) {
-		return ucfirst($field->name) . 'TableRow';
+		return $this->wire()->sanitizer->pascalCase($field->name) . 'TableRow';
 	}
 
 	/**
@@ -499,6 +500,11 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			$this->stubs_path_relative = $data['stubs_path_relative'];
 			$regenerate_stubs = true;
 		}
+		// Inject custom Page class PHPDoc toggle changed
+		if($data['inject_custom_page_class_phpdoc'] !== $this->inject_custom_page_class_phpdoc) {
+			$this->inject_custom_page_class_phpdoc = $data['inject_custom_page_class_phpdoc'];
+			$regenerate_stubs = true;
+		}
 		// Regenerate template stubs checkbox checked
 		if(!empty($data['regenerate_stubs'])) {
 			$regenerate_stubs = true;
@@ -553,8 +559,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			$p1 = $stubs_path . $this->class_prefix . "repeater_matrix_{$field->name}_*.php";
 			$p1 = str_replace('-', '_', $p1);
 			// Match custom page class naming
-			$camelField = ucfirst($this->wire()->sanitizer->camelCase($field->name));
-			$p2 = $stubs_path . "RepeaterMatrix{$camelField}Page_*.php";
+			$fieldPascalName = $this->wire()->sanitizer->pascalCase($field->name);
+			$p2 = $stubs_path . "{$fieldPascalName}RepeaterMatrixPage_*.php";
 			
 			foreach(glob($p1) as $f) $files[] = $f;
 			foreach(glob($p2) as $f) $files[] = $f;
@@ -588,10 +594,10 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 * @param Template $template
 	 */
 	protected function generateTemplateStub(Template $template) {
-		$class_name = $this->getTemplateClassName($template->name);
-		
-		// Determine parent class
 		$extends = 'Page';
+		if($template->name === 'user') {
+			$extends = 'User';
+		}
 		if(strpos($template->name, 'repeater_') === 0) {
 			$fieldName = substr($template->name, 9);
 			$field = $this->wire()->fields->get($fieldName);
@@ -602,20 +608,31 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 					$extends = 'RepeaterPage';
 				}
 			}
+		} else if(strpos($template->name, 'fieldset_') === 0) {
+			$extends = 'FieldsetPage';
 		}
+		$class_name = $this->getTemplateClassName($template->name, $extends);
 
 		$contents = "<?php namespace ProcessWire;\n\n";
 		$template_name = $template->name;
 		if($template->label) $template_name .= " ($template->label)";
-		$contents .= "/**\n * Template: $template_name\n *";
+		$contents .= "/**\n * Template: $template_name\n";
+		$properties = array();
+		$inject_phpdoc = $this->custom_page_class_compatible && $this->inject_custom_page_class_phpdoc;
+		$vars = $inject_phpdoc ? array() : null;
 		foreach($template->fields as $field) {
 			if(in_array((string) $field->type, $this->skip_fieldtypes)) continue;
 			if($field->name === 'repeater_matrix_type') continue;
 			$field_info = $this->getFieldInfo($field, $template);
-			$contents .= "\n * @property {$field_info['returns']} \${$field->name} {$field_info['label']}";
+			$properties[] = " * @property {$field_info['returns']} \${$field->name} {$field_info['label']}";
+			if($inject_phpdoc) $vars[] = "/** @var {$field_info['returns']} \${$field->name} {$field_info['label']} */";
 		}
-		$contents .= "\n */\nclass $class_name extends $extends {}\n";
-		$this->writeStubFile($class_name, $contents);
+		if($properties) $contents .= implode("\n", $properties) . "\n";
+		$contents .= " */\nclass $class_name extends $extends {}\n";
+		if(!$this->inject_custom_page_class_phpdoc) {
+			$this->writeStubFile($class_name, $contents);
+		}
+		if($inject_phpdoc) $this->injectCustomPageClassDoc($template, $vars, $class_name, $extends);
 	}
 
 	/**
@@ -793,8 +810,8 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 */
 	protected function generateMatrixTypeStub(Field $field, $typeName, array $typeInfo) {
 		if($this->custom_page_class_compatible) {
-			$fieldClassName = ucfirst($this->wire()->sanitizer->camelCase($field->name)) . 'Page';
-			$className = "RepeaterMatrix{$fieldClassName}_" . ucfirst($this->wire()->sanitizer->camelCase($typeName));
+			$fieldClassName = $this->wire()->sanitizer->pascalCase($field->name) . 'RepeaterMatrixPage';
+			$className = "{$fieldClassName}_" . $this->wire()->sanitizer->pascalCase($typeName);
 		} else {
 			$typeSlug = str_replace('-', '_', $typeName);
 			$className = "{$this->class_prefix}repeater_matrix_{$field->name}_{$typeSlug}";
@@ -865,12 +882,76 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 	 * @param string $templateName
 	 * @return string
 	 */
-	protected function getTemplateClassName($templateName) {
+	protected function getTemplateClassName($templateName, $extends = null) {
 		if($this->custom_page_class_compatible) {
-			return ucfirst($this->wire()->sanitizer->camelCase($templateName)) . 'Page';
-		} else {
-			return $this->class_prefix . str_replace('-',  '_', $templateName);
+				if($extends === null) {
+					$extends = 'Page';
+					if($templateName === 'user') {
+						$extends = 'User';
+					}
+					if(strpos($templateName, 'repeater_') === 0) {
+						$fieldName = substr($templateName, 9);
+						$field = $this->wire()->fields->get($fieldName);
+						if($field) {
+						if($field->type instanceof FieldtypeRepeaterMatrix) {
+							$extends = 'RepeaterMatrixPage';
+						} elseif($field->type instanceof FieldtypeRepeater) {
+							$extends = 'RepeaterPage';
+						}
+					}
+				} else if(strpos($templateName, 'fieldset_') === 0) {
+					$extends = 'FieldsetPage';
+				}
+			}
+
+			$baseName = $templateName;
+			if($extends === 'RepeaterPage' || $extends === 'RepeaterMatrixPage') {
+				if(strpos($templateName, 'repeater_') === 0) $baseName = substr($templateName, 9);
+			} else if($extends === 'FieldsetPage' && strpos($templateName, 'fieldset_') === 0) {
+				$baseName = substr($templateName, 9);
+			}
+
+			$pascal = $this->wire()->sanitizer->pascalCase($baseName);
+			if($extends === 'RepeaterPage') return $pascal . 'RepeaterPage';
+			if($extends === 'RepeaterMatrixPage') return $pascal . 'RepeaterMatrixPage';
+			if($extends === 'FieldsetPage') return $pascal . 'FieldsetPage';
+			return $pascal . 'Page';
 		}
+		return $this->class_prefix . str_replace('-',  '_', $templateName);
+	}
+
+	/**
+	 * Inject AutoTemplateStubs properties into native custom Page class
+	 *
+	 * @param Template $template
+	 * @param array $properties
+	 */
+	protected function injectCustomPageClassDoc(Template $template, array $vars, $className, $extends) {
+		if(!$this->custom_page_class_compatible) return;
+		if(!$this->inject_custom_page_class_phpdoc) return;
+		if(empty($vars)) return;
+		$classesPath = $this->wire()->config->paths->classes;
+		if(!is_dir($classesPath)) $this->wire()->files->mkdir($classesPath, true);
+		$filePath = $classesPath . "$className.php";
+		if(!is_file($filePath)) {
+			$region = "//region AutoTemplateStubs\n//endregion";
+			$contents = "<?php namespace ProcessWire;\n\n";
+			$contents .= "$region\n";
+			$contents .= "class $className extends $extends {\n";
+			$contents .= "}\n";
+			$this->wire()->files->filePutContents($filePath, $contents);
+		}
+		if(!is_file($filePath) || !is_writable($filePath)) return;
+		$contents = file_get_contents($filePath);
+		if($contents === false) return;
+		$regionPattern = '/\/\/region AutoTemplateStubs\s*.*?\s*\/\/endregion/s';
+		if(!preg_match($regionPattern, $contents)) return;
+		$regionLines = array('//region AutoTemplateStubs');
+		foreach($vars as $line) $regionLines[] = $line;
+		$regionLines[] = '//endregion';
+		$region = implode("\n", $regionLines);
+		$contents = preg_replace($regionPattern, $region, $contents, 1);
+		$this->wire()->files->filePutContents($filePath, $contents);
 	}
 
 	/**
@@ -965,6 +1046,20 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 		$f->label = sprintf($this->_('Name stub classes for compatibility with [custom Page classes](%s)'), 'https://processwire.com/blog/posts/pw-3.0.152/#new-ability-to-specify-custom-page-classes');
 		$f->notes = $this->_('If checked stub classes will be named according to the camel case "[TemplateName]Page" format used for custom page classes, e.g. BlogPostPage');
 		$f->checked = $this->$f_name === 1 ? 'checked' : '';
+		$inputfields->add($f);
+
+		/** @var InputfieldCheckbox $f */
+		$f = $modules->get('InputfieldCheckbox');
+		$f_name = 'inject_custom_page_class_phpdoc';
+		$f->name = $f_name;
+		$f->label = $this->_('Inject PHPDoc into custom Page classes');
+		$f->description = $this->_('When enabled, AutoTemplateStubs updates files in /site/classes by replacing the region "AutoTemplateStubs". **Warning: This edits your existing class files.**');
+		$f->notes = $this->_('Only the region block is modified. For existing classes, you must add the region marker manually. If a class does not exist yet, an empty class file with the region marker will be created.  
+		```//region AutoTemplateStubs
+		//endregion```');
+
+		$f->checked = $this->$f_name === 1 ? 'checked' : '';
+		$f->showIf = 'custom_page_class_compatible=1';
 		$inputfields->add($f);
 
 		/** @var InputfieldText $f */

--- a/AutoTemplateStubs.module.php
+++ b/AutoTemplateStubs.module.php
@@ -434,7 +434,10 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 		if($fieldType === 'FieldtypeCombo') $this->generateComboStub($field);
 		if($fieldType === 'FieldtypeTable') $this->generateTableStubs($field);
 		if($fieldType === 'FieldtypeTextareas') $this->generateTextareasStub($field);
-		if($fieldType === 'FieldtypeRepeaterMatrix') $this->generateMatrixStub($field);
+		if($fieldType === 'FieldtypeRepeaterMatrix') {
+			$this->deleteFieldStub($field);
+			$this->generateMatrixStub($field);
+		}
 		if($fieldType === 'FieldtypeCustom') $this->generateCustomFieldStub($field);
 		
 		foreach($templates as $template) {

--- a/AutoTemplateStubs.module.php
+++ b/AutoTemplateStubs.module.php
@@ -625,7 +625,7 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 			if($field->name === 'repeater_matrix_type') continue;
 			$field_info = $this->getFieldInfo($field, $template);
 			$properties[] = " * @property {$field_info['returns']} \${$field->name} {$field_info['label']}";
-			if($inject_phpdoc) $vars[] = "/** @var {$field_info['returns']} \${$field->name} {$field_info['label']} */";
+			if($inject_phpdoc) $vars[] = " * @property {$field_info['returns']} \${$field->name} {$field_info['label']}";
 		}
 		if($properties) $contents .= implode("\n", $properties) . "\n";
 		$contents .= " */\nclass $class_name extends $extends {}\n";
@@ -947,7 +947,9 @@ class AutoTemplateStubs extends WireData implements Module, ConfigurableModule {
 		$regionPattern = '/\/\/region AutoTemplateStubs\s*.*?\s*\/\/endregion/s';
 		if(!preg_match($regionPattern, $contents)) return;
 		$regionLines = array('//region AutoTemplateStubs');
+		$regionLines[] = '/**';
 		foreach($vars as $line) $regionLines[] = $line;
+		$regionLines[] = ' */';
 		$regionLines[] = '//endregion';
 		$region = implode("\n", $regionLines);
 		$contents = preg_replace($regionPattern, $region, $contents, 1);


### PR DESCRIPTION
This PR adds optional PHPDoc injection into native custom Page classes to improve IDE support.

Summary:

- Add config option to inject PHPDoc into /site/classes using //region AutoTemplateStubs.
- Auto-create empty class files with the region marker when missing; update only the region block for existing classes. (Field stubs are still generated in the custom stubs directory)
- Use PascalCase naming for custom Page class compatibility.
- Adjust Repeater/RepeaterMatrix/FieldsetPage class naming to match custom Page class conventions.
